### PR TITLE
Add some Pro Feature labels

### DIFF
--- a/includes/form-elements.php
+++ b/includes/form-elements.php
@@ -64,11 +64,16 @@ function buddyforms_moderation_admin_settings_sidebar_metabox_html() {
 	if ( isset( $buddyform['moderation']['frontend-moderators'] ) ) {
 		$frontend_moderators = $buddyform['moderation']['frontend-moderators'];
 	}
-	$form_setup[] = new Element_Select( '<b>' . __( 'Frontend Moderators Role', 'buddyforms-moderation' ) . '</b>', "buddyforms_options[moderation][frontend-moderators]", $roles_array, array(
+	$element = new Element_Select( '<b>' . __( 'Frontend Moderators Role', 'buddyforms-moderation' ) . '</b>', "buddyforms_options[moderation][frontend-moderators]", $roles_array, array(
 		'value'     => $frontend_moderators,
 		'shortDesc' => __( 'Select which role the users will need to moderate the content from the front. This option takes precedence over the moderation field so it would not be shown to the user.', 'buddyforms-moderation' )
 	) );
 
+	if ( buddyforms_members_fs()->is_not_paying() ) {
+		$element->setAttribute( 'disabled', 'disabled' );
+	}
+	
+	$form_setup[] = $element;
 
 	$element_name    = 'buddyforms_options[moderation][reject_subject]';
 	$shortcodes_html = buddyforms_moderation_element_shortcodes_helper( $buddyform, $element_name );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -925,3 +925,28 @@ function buddyforms_moderation_include_assets() {
 }
 
 add_action( 'buddyforms_front_js_css_after_enqueue', 'buddyforms_moderation_include_assets' );
+
+/**
+ * Add Moderation form elements in the form elements select box
+ *
+ * @param $elements_select_options
+ *
+ * @return mixed
+ */
+function buddyforms_moderators_select( $elements_select_options ) {
+	global $post;
+
+	if ( $post->post_type != 'buddyforms' ) {
+		return $elements_select_options;
+	}
+	$elements_select_options['moderators']['label']                = __( 'Moderation', 'buddyforms-moderation' );
+	$elements_select_options['moderators']['class']                = 'bf_show_if_f_type_post';
+	$elements_select_options['moderators']['fields']['moderators'] = array(
+		'is_pro' => true,
+		'label' => __( 'Select Moderators ', 'buddyforms-moderation' ),
+	);
+
+	return $elements_select_options;
+}
+
+add_filter( 'buddyforms_add_form_element_select_option', 'buddyforms_moderators_select', 1, 2 );

--- a/includes/moderators-form-element.php
+++ b/includes/moderators-form-element.php
@@ -1,31 +1,5 @@
 <?php
 
-
-/**
- * Add Moderation form elements in the form elements select box
- *
- * @param $elements_select_options
- *
- * @return mixed
- */
-function buddyforms_moderators_select( $elements_select_options ) {
-	global $post;
-
-	if ( $post->post_type != 'buddyforms' ) {
-		return $elements_select_options;
-	}
-	$elements_select_options['moderators']['label']                = __( 'Moderation', 'buddyforms-moderation' );
-	$elements_select_options['moderators']['class']                = 'bf_show_if_f_type_post';
-	$elements_select_options['moderators']['fields']['moderators'] = array(
-		'label' => __( 'Select Moderators ', 'buddyforms-moderation' ),
-	);
-
-	return $elements_select_options;
-}
-
-add_filter( 'buddyforms_add_form_element_select_option', 'buddyforms_moderators_select', 1, 2 );
-
-
 /**
  * Create the new Builder Form Elements
  *


### PR DESCRIPTION
- Improve visibility of the Moderator form field, adding it to form field selector on the Builder as a  - PRO element. 
- Add pro labels in the "Frontend Moderators Role" selector. This option was pointless on the free version.

More here: 
https://www.loom.com/share/1d1b616cd4b1472187a22d32fab2b2d0